### PR TITLE
chore: update travis-ci file for maintained php versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.3
+  - 7.4
+  - 8.0
   - nightly
 script:
   - composer install
@@ -10,4 +10,4 @@ script:
 after_success:
   - curl -OL https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar
   - php phpcs.phar -n --standard=PSR1,PSR2 src/
-dist: trusty
+dist: focal


### PR DESCRIPTION
This request is to update the versions in the Travis-CI file for the supported PHP versions as of July 2021:

- 7.3 (maintenance until December 2021)
- 7.4 (active or maintenance until November 2022)
- 8.0 (active or maintenance until November 2023)